### PR TITLE
On macOS, compile C with clang.

### DIFF
--- a/build/gnat/sdlada.gpr
+++ b/build/gnat/sdlada.gpr
@@ -49,6 +49,17 @@ library project SDLAda is
             Common_Switches := Common_Switches & ("-O2");
       end case;
 
+      --  All GCC releases up to & including 13.2 give errors when
+      --  using SDK 15, because Apple have used a new macro
+      --  unsupported by GCC.
+      case Platform is
+         when "macos_homebrew" | "macos_ports" =>
+            for Driver ("C") use "clang";
+
+         when others =>
+            null;
+      end case;
+
       --  These flags require checking on all platforms as they're taken directly from sdl2-config.
       case Platform is
          when "linux" | "bsd" | "android" | "windows" =>


### PR DESCRIPTION
In SDK 15, Apple have used a macro (`__has_extension()`) which isn't supported by GCC up to and including 13.2. It will be supported in 13.3 and 14.1.

See [this StackOverflow question](https://stackoverflow.com/questions/78363274/cannot-build-sdl-ada-bindings-on-osx-sonoma-because-of-error-missing-binary-ope) & my answer, also [this Homebrew discussion](https://github.com/orgs/Homebrew/discussions/5195).

Unfortunately the unfixed version works fine under Github CI, and I don’t see how to update to show that it doesn’t work with SDK 15.